### PR TITLE
feat(cnpg): support cluster.enablePDB passthrough

### DIFF
--- a/charts/helm-base/templates/cnpg-cluster.yaml
+++ b/charts/helm-base/templates/cnpg-cluster.yaml
@@ -10,7 +10,11 @@ metadata:
     app.kubernetes.io/component: database
 spec:
   instances: {{ .Values.cnpg.cluster.instances }}
-  
+
+  {{- if hasKey .Values.cnpg.cluster "enablePDB" }}
+  enablePDB: {{ .Values.cnpg.cluster.enablePDB }}
+  {{- end }}
+
   {{- if .Values.cnpg.cluster.imageName }}
   imageName: {{ .Values.cnpg.cluster.imageName }}
   {{- else }}


### PR DESCRIPTION
## What
Render `spec.enablePDB` on the CNPG Cluster when `cnpg.cluster.enablePDB` is set in values (guarded by `hasKey`, so CNPG's default is preserved when omitted).

## Why
The template previously had no way to set `enablePDB`. CNPG auto-creates per-cluster PodDisruptionBudgets that sit at **ALLOWED DISRUPTIONS = 0** for single-instance clusters (and for the primary of HA clusters), which **blocks every node drain** — this repeatedly forced manual pod-deletes + brief downtime during the prod cluster consolidation. Consumers can now set `cnpg.cluster.enablePDB: false` to opt out.

## Propagation
CI (publish.yml) auto-bumps the patch version and publishes to the gh-pages chart repo on merge. Consumers pin `helm-base version: 0.1` (range), so they pick up the new 0.1.x on their next `helm dependency update` / redeploy. The companion value-side PRs (whizai-platform, guzzy-world, meanscoop, r3verb) set `enablePDB: false` and depend on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)