### PR TITLE
fix(helm-base): merge duplicate kafka template blocks; add hasKey guards for cnpg nodeSelector/tolerations

### DIFF
--- a/charts/helm-base/templates/cnpg-cluster.yaml
+++ b/charts/helm-base/templates/cnpg-cluster.yaml
@@ -97,12 +97,12 @@ spec:
     topologyKey: {{ .Values.cnpg.cluster.affinity.topologyKey | default "topology.kubernetes.io/zone" }}
   {{- end }}
   
-  {{- if .Values.cnpg.cluster.nodeSelector }}
+  {{- if hasKey .Values.cnpg.cluster "nodeSelector" }}
   nodeSelector:
     {{- toYaml .Values.cnpg.cluster.nodeSelector | nindent 4 }}
   {{- end }}
-  
-  {{- if .Values.cnpg.cluster.tolerations }}
+
+  {{- if hasKey .Values.cnpg.cluster "tolerations" }}
   tolerations:
     {{- toYaml .Values.cnpg.cluster.tolerations | nindent 4 }}
   {{- end }}
@@ -112,7 +112,14 @@ spec:
     {{- toYaml .Values.cnpg.cluster.env | nindent 4 }}
   {{- end }}
   
-  {{- if and .Values.cnpg.backup.enabled .Values.cnpg.backup.s3.enabled }}
+  {{- if .Values.cnpg.backup.enabled }}
+  {{- if .Values.cnpg.backup.barmanObjectStore }}
+  backup:
+    barmanObjectStore:
+      {{- toYaml .Values.cnpg.backup.barmanObjectStore | nindent 6 }}
+    retentionPolicy: {{ .Values.cnpg.backup.retentionPolicy | default "7d" }}
+  {{- else if .Values.cnpg.backup.s3 }}
+  {{- if .Values.cnpg.backup.s3.enabled }}
   backup:
     barmanObjectStore:
       destinationPath: s3://{{ .Values.cnpg.backup.s3.bucket }}{{ .Values.cnpg.backup.s3.path }}
@@ -136,15 +143,19 @@ spec:
         {{- else }}
         inheritFromIAMRole: true
         {{- end }}
+      {{- if .Values.cnpg.backup.wal }}
       {{- if .Values.cnpg.backup.wal.enabled }}
       wal:
         compression: {{ .Values.cnpg.backup.wal.compression | default "gzip" }}
         maxParallel: 2
       {{- end }}
+      {{- end }}
       data:
         compression: gzip
         jobs: 2
     retentionPolicy: {{ .Values.cnpg.backup.retentionPolicy | default "7d" }}
+  {{- end }}
+  {{- end }}
   {{- end }}
   
   {{- if .Values.serviceAccount.create }}

--- a/charts/helm-base/templates/kafka-cluster.yaml
+++ b/charts/helm-base/templates/kafka-cluster.yaml
@@ -55,9 +55,10 @@ spec:
       {{- toYaml .Values.kafka.cluster.jvmOptions | nindent 6 }}
     {{- end }}
     
-    {{- if .Values.kafka.cluster.affinity.enablePodAntiAffinity }}
+    {{- if or .Values.kafka.cluster.affinity.enablePodAntiAffinity .Values.kafka.cluster.nodeSelector .Values.kafka.cluster.tolerations }}
     template:
       pod:
+        {{- if .Values.kafka.cluster.affinity.enablePodAntiAffinity }}
         affinity:
           podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
@@ -72,20 +73,15 @@ spec:
                       values:
                         - {{ .Values.kafka.cluster.name | default (include "helm-base.fullname" .) }}-kafka
                 topologyKey: {{ .Values.kafka.cluster.affinity.topologyKey | default "topology.kubernetes.io/zone" }}
-    {{- end }}
-    
-    {{- if .Values.kafka.cluster.nodeSelector }}
-    template:
-      pod:
+        {{- end }}
+        {{- if .Values.kafka.cluster.nodeSelector }}
         nodeSelector:
           {{- toYaml .Values.kafka.cluster.nodeSelector | nindent 10 }}
-    {{- end }}
-    
-    {{- if .Values.kafka.cluster.tolerations }}
-    template:
-      pod:
+        {{- end }}
+        {{- if .Values.kafka.cluster.tolerations }}
         tolerations:
           {{- toYaml .Values.kafka.cluster.tolerations | nindent 10 }}
+        {{- end }}
     {{- end }}
 
   {{- if .Values.kafka.zookeeper.enabled }}


### PR DESCRIPTION
## Summary

- **kafka-cluster.yaml**: Three separate `template.pod` blocks (for `affinity`, `nodeSelector`, and `tolerations`) were duplicate YAML keys — in YAML, duplicate keys mean only the last one wins, so `podAntiAffinity` was silently dropped. Merged all three into a single `{{- if or ... }}` guarded `template.pod` block.
- **cnpg-cluster.yaml**: Upgraded `nodeSelector` and `tolerations` guards from plain `{{- if .Values... }}` to `{{- if hasKey .Values.cnpg.cluster "..." }}` so an explicitly set empty map is still passed through to the CR. Also includes a `barmanObjectStore` passthrough block and WAL nil-guard from a related branch that had been left unstaged.

## Test plan

- [ ] `helm template` a release with `kafka.cluster.affinity.enablePodAntiAffinity=true` and `kafka.cluster.nodeSelector` set — verify all three fields appear in the output (previously only `tolerations` would render)
- [ ] `helm template` with `cnpg.cluster.nodeSelector: {}` (empty map) — verify `nodeSelector: {}` appears in the Cluster CR
- [ ] `helm template` with neither key set — verify neither field appears (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)